### PR TITLE
Add ability to register colspans in table headers

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -221,20 +221,21 @@ function formatTable(elem, fn, options) {
             switch (elem.name.toLowerCase()) {
               case 'th':
                 tokens = formatHeading(elem, fn, options).split('\n');
-                rows.push(compact(tokens));
                 break;
 
               case 'td':
                 tokens = fn(elem.children, options).split('\n');
-                rows.push(compact(tokens));
-                // Fill colspans with empty values
-                if (elem.attribs && elem.attribs.colspan) {
-                  count = elem.attribs.colspan - 1 || 0;
-                  times(count, function() {
-                    rows.push(['']);
-                  });
-                }
                 break;
+            }
+            if (tokens) {
+              rows.push(compact(tokens));
+              // Fill colspans with empty values
+              if (elem.attribs && elem.attribs.colspan) {
+                count = elem.attribs.colspan - 1 || 0;
+                times(count, function() {
+                  rows.push(['']);
+                });
+              }
             }
           }
         });

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -192,6 +192,31 @@ describe('html-to-text', function() {
       var result = htmlToText.fromString(html, { tables: true });
       expect(result).to.equal(resultExpected);
     });
+    it('does handle colspan on th elements correctly', function () {
+      var html = '\
+        <table> \
+        <tr> \
+        <th>header column 1</th> \
+        <th colspan="2">header columns 2 and 3</th> \
+        <th>header column 4</th> \
+        </tr> \
+        <tbody> \
+        <tr> \
+        <td>column 1</td> \
+        <td>column 2</td> \
+        <td>column 3</td> \
+        <td>column 4</td> \
+        </tr> \
+        </center> \
+        </tbody> \
+        </table> \
+      ';
+      var resultExpected = ' HEADER COLUMN 1   HEADER COLUMNS 2 AND 3              HEADER COLUMN 4   \n\
+column 1          column 2                 column 3   column 4';
+      var result = htmlToText.fromString(html, { tables: true });
+      expect(result).to.equal(resultExpected);
+    });
+
   });
 
   describe('a', function () {

--- a/test/test.html
+++ b/test/test.html
@@ -30,6 +30,7 @@
 						<thead>
 						<tr>
 							<th>Article</th>
+							<th colspan="2">Notes</th>
 							<th>Price</th>
 							<th>Taxes</th>
 							<th>Amount</th>
@@ -44,6 +45,8 @@
 									<span style="font-size:0.8em">Contains: 1x Product 1</span>
 								</p>
 							</td>
+							<td align="right" valign="top">one</td>
+							<td align="right" valign="top">two</td>
 							<td align="right" valign="top">6,99&euro;</td>
 							<td align="right" valign="top">7%</td>
 							<td align="right" valign="top">1</td>
@@ -51,6 +54,8 @@
 						</tr>
 						<tr>
 							<td>Shipment costs</td>
+							<td align="right" valign="top"></td>
+							<td align="right" valign="top">two</td>
 							<td align="right">3,25€</td>
 							<td align="right">7%</td>
 							<td align="right">1</td>
@@ -59,9 +64,11 @@
 						<tr>
 							<td>&nbsp;</td>
 							<td>&nbsp;</td>
+							<td>&nbsp;</td>
 							<td colspan="3">to pay: 10,24€</td>
 						</tr>
 						<tr>
+							<td></td>
 							<td></td>
 							<td></td>
 							<td colspan="3">Taxes 7%: 0,72€</td>

--- a/test/test.txt
+++ b/test/test.txt
@@ -17,12 +17,12 @@ takimata sanctus est Lorem ipsum dolor sit amet.
 --------------------------------------------------------------------------------
 
 PRETTY PRINTED TABLE
-ARTICLE                  PRICE   TAXES             AMOUNT   TOTAL   
-Product 1                6,99€   7%                1        6,99€   
-Contains: 1x Product 1                                              
-Shipment costs           3,25€   7%                1        3,25€   
-                                 to pay: 10,24€                     
-                                 Taxes 7%: 0,72€                    
+ARTICLE                  NOTES         PRICE             TAXES   AMOUNT   TOTAL   
+Product 1                one     two   6,99€             7%      1        6,99€   
+Contains: 1x Product 1                                                            
+Shipment costs                   two   3,25€             7%      1        3,25€   
+                                       to pay: 10,24€                     
+                                       Taxes 7%: 0,72€                    
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Forked version of https://github.com/werk85/node-html-to-text/pull/155 as that project seems unmaintained?

* fixup of https://github.com/werk85/node-html-to-text/pull/144
* update integration test to cover new colspan functionality
* update unit tests to cover new colspan functionality